### PR TITLE
Stage ffmpeg from jammy instead of building from source

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,10 +58,10 @@ parts:
       - libjpeg-turbo8-dev
     prime:
       - usr/lib/*/libmpv*
-      
+  
   celluloid-snap:
     source: https://github.com/celluloid-player/celluloid.git
-    after: [ffmpeg, mpv]
+    after: [mpv]
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -87,71 +87,12 @@ parts:
       - libv4lconvert0
       - liblapack3
       - libblas3
-  
-  ffmpeg:
-    plugin: autotools
-    source: https://ffmpeg.org/releases/ffmpeg-4.4.4.tar.xz
-    autotools-configure-parameters:
-      - --prefix=/usr
-      - --disable-debug
-      - --disable-doc
-      - --disable-static
-      - --enable-gpl
-      - --enable-shared
-      - --enable-avcodec
-      - --enable-libfdk-aac
-      - --enable-libopenh264
-      - --enable-libvpx
-      - --enable-opengl
-      - --enable-vaapi 
-      - --enable-libcdio 
-      - --enable-libbluray
-      - --enable-libass 
-      - --enable-libaom  
-      - --enable-ladspa
-      - --enable-alsa
-      - --enable-vdpau 
-      - --enable-avformat  
-      - --enable-swresample
-      - --disable-ffplay
-      - --enable-nonfree
-      - --disable-devices
-      - --enable-gnutls
-      - --enable-libmp3lame
-      - --enable-libvorbis
-    build-packages:
-      - nasm
-      - libgnutls28-dev
-      - libsdl2-dev
-      - libtool
-      - libva-dev
-      - libvdpau-dev
-      - libass-dev
-      - libopenh264-dev
-      - libxcb1-dev
-      - libx264-dev
-      - libopus-dev
-      - libaom-dev
-      - libdav1d-dev
-      - libvpx-dev
-      - libbluray-dev
-      - libx265-dev 
-      - ladspa-sdk-dev
-      - libnuma-dev
-      - libcdio-paranoia-dev
-      - libcdio++-dev
+      - ffmpeg
       - libffmpeg-nvenc-dev
-      - libcdio-cdda-dev
-      - libfdk-aac-dev
-      - libmp3lame-dev
-      - libcdio-dev
-      - libvorbis-dev
-    stage-packages:
-      - libmp3lame0
-      - libass9
   
+ 
   cleanup:
-    after: [celluloid-snap, ffmpeg]
+    after: [celluloid-snap]
     plugin: nil
     build-snaps: [core22, gtk-common-themes, gnome-42-2204]
     override-prime: |


### PR DESCRIPTION
ffmpeg from source makes the snap unusable for some yet unknown reason, but snap works fine with jammy's ffmpeg but using from jammy significantly bloats the snap.